### PR TITLE
スポット写真のプレビューの表示

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,8 +11,9 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require bootstrap-sprockets
 //= require jquery
+//= require jquery_ujs
 //= require cocoon
 //= require turbolinks
+//= require bootstrap
 //= require_tree .

--- a/app/assets/javascripts/preview_images.coffee
+++ b/app/assets/javascripts/preview_images.coffee
@@ -1,34 +1,32 @@
 class previewImages
   constructor: (@$root) ->
-    console.log 'a'
     @bind()
 
   bind: =>
-    @$root.on 'change', '.photos', @createPreview
+    @$root.on "change", ".photos", @createPreview
     return
 
   createPreview: (e) =>
-    console.log 'b'
     files = e.target.files
     parent = e.target.parentNode
     @resetPreview(parent)
     for file in files
       reader = new FileReader()
       reader.readAsDataURL file
-      reader.addEventListener 'load', (re) ->
-        li = document.createElement 'li'
-        li.className = 'preview'
-        img = document.createElement 'img'
+      reader.addEventListener "load", (re) ->
+        li = document.createElement "li"
+        li.className = "preview"
+        img = document.createElement "img"
         img.src = re.target.result
         li.appendChild img
-        parent.querySelector('.photo_area').appendChild(li)
+        parent.querySelector(".photo_area").appendChild(li)
     return
 
   resetPreview: (parent) =>
-    previews = $(parent).find '.preview'
+    previews = $(parent).find ".preview"
     for preview in previews
       $(preview).remove()
     return
 
-$(window).load ->
-  new previewImages($('.spot_container'))
+$(document).on "turbolinks:load", ->
+  new previewImages($(".spot_container"))

--- a/app/assets/javascripts/preview_images.coffee
+++ b/app/assets/javascripts/preview_images.coffee
@@ -1,0 +1,34 @@
+class previewImages
+  constructor: (@$root) ->
+    console.log 'a'
+    @bind()
+
+  bind: =>
+    @$root.on 'change', '.photos', @createPreview
+    return
+
+  createPreview: (e) =>
+    console.log 'b'
+    files = e.target.files
+    parent = e.target.parentNode
+    @resetPreview(parent)
+    for file in files
+      reader = new FileReader()
+      reader.readAsDataURL file
+      reader.addEventListener 'load', (re) ->
+        li = document.createElement 'li'
+        li.className = 'preview'
+        img = document.createElement 'img'
+        img.src = re.target.result
+        li.appendChild img
+        parent.querySelector('.photo_area').appendChild(li)
+    return
+
+  resetPreview: (parent) =>
+    previews = $(parent).find '.preview'
+    for preview in previews
+      $(preview).remove()
+    return
+
+$(window).load ->
+  new previewImages($('.spot_container'))

--- a/app/views/plans/_form.html.haml
+++ b/app/views/plans/_form.html.haml
@@ -10,8 +10,9 @@
     = f.label :description
     = f.text_area :description, rows:5, class: "form-control"
   %h2= t("title.register_spot")
-  = f.fields_for :spots do |spot|
-    = render "spot_fields", f: spot
-  .links
-    = link_to_add_association f, :spots, class: "btn btn-success"
+  .spot_container
+    = f.fields_for :spots do |spot|
+      = render "spot_fields", f: spot
+    .links
+      = link_to_add_association f, :spots, class: "btn btn-success"
   = f.submit class: "btn btn-primary"

--- a/app/views/plans/_spot_fields.html.haml
+++ b/app/views/plans/_spot_fields.html.haml
@@ -7,9 +7,9 @@
     = f.text_area :description, rows: 5, class: "form-control"
   .form-group
     = f.label :photos
-    - if f.object.photos.any?
-      %ul.image-area
+    %ul.photo_area
+      - if f.object.photos.any?
         - f.object.photos.each do |photo|
           %li= image_tag photo.thumb.url
-    = f.file_field :photos, multiple: true
+    = f.file_field :photos, multiple: true, class: "photos"
   = link_to_remove_association f, class: "btn btn-danger"


### PR DESCRIPTION
# 概要
スポット写真のプレビューを表示させる

# 関連Issue
https://github.com/toyokappa/tabimemo/issues/26

# 仕様
* 画像が選択された際に、その画像のプレビューをファイル追加ボタンの上に表示させる
* Turbolinksによるイベント未発火の改善