### PR TITLE
レベルアップをクリック時にプロフィールページに遷移

### DIFF
--- a/app/assets/javascripts/level_up_toast.coffee
+++ b/app/assets/javascripts/level_up_toast.coffee
@@ -5,6 +5,7 @@ class LevelUpToast
 
   displayToast: =>
     level = @$root.data().level
+    user = @$root.data().user
     toastr.success("Lv.#{level}になりました！", "レベルアップ")
 
     token = $('meta[name="csrf_token"]').attr('content')
@@ -13,6 +14,6 @@ class LevelUpToast
       method: "PATCH",
       data: { authenticity_token: token },
     )
-
+    $('#toast-container').on('click', -> window.location.href = "/#{user}/profile")
 $(document).on "turbolinks:load", ->
   new LevelUpToast $("#level-up-toast") if $("#level-up-toast")[0]

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -68,6 +68,6 @@
         .copyrights
           2018 &copy; Toyokappa, All Rights Reserved.
 - if user_signed_in? && current_user.level_up?
-  #level-up-toast{ data: { level: current_user.level } }
+  #level-up-toast{ data: { level: current_user.level, user: current_user.name } }
 - if user_signed_in? && current_user.got_trophy_name
   #got-trophy-toast{ data: { trophy: Trophy.human_attribute_name(current_user.got_trophy_name), user: current_user.name } }


### PR DESCRIPTION
<h3>内容</h3>
<p>レベルアップをクリックした時プロフィールページに飛ぶように設定しました。</p>

<h3>実装</h3>
<p>一応自分でも何か別の方法はないか確かめましたが、なべさんが既にトロフィーの方で同じことをやっていたので合わせたほうが良いと思い同じような実装にしました。</p>

<h3>参考文献</h3>

https://github.com/tylergannon/toastr-rails
https://stackoverflow.com/questions/2238368/how-to-make-a-button-redirect-to-another-page-using-jquery-or-just-javascript
https://qiita.com/luccafort/items/424e4990ad88d576a5bd
